### PR TITLE
Partial fix for the zoom to districts problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,23 +64,28 @@
 			}
 
 			function zoomToPolygon(sourceID, itemID, fieldName) {
-				// first quickly zoom out to the full layer area
-				map.fitBounds(map.getSource(sourceID).bounds, options={duration: 0});
-				// if we haven't passed in an itemID, then just stop there; otherwise continue with the zoom in
+				// if we have an itemID, then do the main work
 				if (typeof itemID !== 'undefined') {
+					layerBounds = map.getSource(sourceID).bounds;
+					layerID = map.getSource(sourceID).vectorLayerIds[0];
+					features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID});
+					// now zoom out and requery features to make sure we don't miss anything from having been zoomed in
+					map.fitBounds(bounds, options={duration: 0, padding: 100});
 					// use a timeout here to make sure that the zoom in doesn't try to start before the zoom out has finished
 					setTimeout(
 						function(){
-							layerBounds = map.getSource(sourceID).bounds;
-							layerID = map.getSource(sourceID).vectorLayerIds[0];
-							features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
+							console.log(layerBounds, layerID, features);
+							features = features.concat(map.querySourceFeatures(sourceID, {'sourceLayer': layerID}));
+							console.log(layerBounds, layerID, features);
 							minX = layerBounds[2];
 							maxX = layerBounds[0];
 							minY = layerBounds[3];
 							maxY = layerBounds[1];
+							itemFound = false;
 							// then step through features - first to find the item we want
 							for (i in features) {
 								if (features[i].properties[fieldName] == itemID) {
+									itemFound = true;
 									coords = features[i].toJSON().geometry.coordinates;
 									for (j in coords) {
 										// then the coords returned may be a simple array of coords, or an array of arrays if it's a multipolygon
@@ -101,10 +106,15 @@
 											}
 										}
 									}
+									console.log(itemID, i, minX, minY, maxX, maxY, coords);
 								}
 							}
-							// having found the bounds, the rest is easy
-							map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
+							// if we found any bounds, zoom to them
+							console.log(minX, minY, maxX, maxY);
+							console.log(layerBounds);
+							if (itemFound) {
+								map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
+							}
 						},
 						100
 					); // end of setTimeout block
@@ -192,6 +202,8 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWI
 			var bounds = [
 					[-114.9594,21.637], // southwest coords
 					[-85.50,39.317] // northeast coords
+//					[-116,21], // southwest coords
+//					[-85,40] // northeast coords
 				];
 
 

--- a/index.html
+++ b/index.html
@@ -190,8 +190,8 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWI
 
 //set bounds to Texas
 			var bounds = [
-					[-114.9594,15.637], // southwest coords
-					[-60.50,48.317] // northeast coords
+					[-114.9594,21.637], // southwest coords
+					[-85.50,39.317] // northeast coords
 				];
 
 

--- a/index.html
+++ b/index.html
@@ -30,8 +30,6 @@
 				}
 				else {
 					populateZoomControl("school-districts-control", "texas-school-districts", "NAME", "Texas School Districts");
-					//populateZoomControl("house-districts-control", "state-house-districts", "District", "State House Districts");
-					//populateZoomControl("senate-districts-control", "state-senate-districts", "District", "State Senate Districts");
 				}
 			}
 
@@ -74,9 +72,7 @@
 					// use a timeout here to make sure that the zoom in doesn't try to start before the zoom out has finished
 					setTimeout(
 						function(){
-//							console.log(layerBounds, layerID, features);
 							features = features.concat(map.querySourceFeatures(sourceID, {'sourceLayer': layerID}));
-//							console.log(layerBounds, layerID, features);
 							minX = layerBounds[2];
 							maxX = layerBounds[0];
 							minY = layerBounds[3];
@@ -106,12 +102,9 @@
 											}
 										}
 									}
-//									console.log(itemID, i, minX, minY, maxX, maxY, coords);
 								}
 							}
 							// if we found any bounds, zoom to them
-//							console.log(minX, minY, maxX, maxY);
-//							console.log(layerBounds);
 							if (itemFound) {
 								map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
 							}
@@ -141,9 +134,6 @@
 
 				<select id="school-districts-control" onchange="zoomToPolygon('texas-school-districts', this.value, 'NAME');"></select>
 				<br /><br />
-				<!--<select id="house-districts-control" onchange="zoomToPolygon('state-house-districts', this.value, 'District');"></select>
-				<br /><br />
-				<select id="senate-districts-control" onchange="zoomToPolygon('state-senate-districts', this.value, 'District');"></select>-->
 
 				<br /><br />
 				Map produced by <a href="http://www.coregis.net/" target="_blank">CoreGIS</a>.
@@ -202,8 +192,6 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWI
 			var bounds = [
 					[-114.9594,21.637], // southwest coords
 					[-85.50,39.317] // northeast coords
-//					[-116,21], // southwest coords
-//					[-85,40] // northeast coords
 				];
 
 
@@ -456,29 +444,6 @@ map.on('load', function () {
 			runWhenLoadComplete();
 
 		}); // end of map.on(load) block
-
-	/*
-	// When a click event occurs on a feature in the charter schools layer, open a popup at the
-    // location of the click, with description HTML from its properties.
-
-   map.on('click', function(e) {
-		  var features = map.queryRenderedFeatures(e.point, {
-			layers: ['charter-schools-v1-6wolgf'] // replace this with the name of the layer
-		  });
-
-		  if (!features.length) {
-			return;
-		  }
-
-		  var feature = features[0];
-
-		  var popup = new mapboxgl.Popup({ offset: [0, -15] })
-			.setLngLat(feature.geometry.coordinates)
-			.setHTML("<span class='varname'>School Name: </span><span class='attribute'>" + feature.properties.CAMPNAME + "<br><span class='varname'>Charter Type: </span><span class='attribute'>" + feature.properties.CHART_TYPE )
-			.setLngLat(feature.geometry.coordinates)
-			.addTo(map);
-		});
-		*/
 
 // Add zoom controls to the map, with the compass turned off; position is modified in CSS
 		map.addControl(new mapboxgl.NavigationControl({

--- a/index.html
+++ b/index.html
@@ -190,8 +190,8 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiY29yZS1naXMiLCJhIjoiaUxqQS1zQSJ9.mDT5nb8l_dWI
 
 //set bounds to Texas
 			var bounds = [
-					[-114.9594,21.637], // southwest coords
-					[-85.50,39.317] // northeast coords
+					[-114.9594,15.637], // southwest coords
+					[-60.50,48.317] // northeast coords
 				];
 
 

--- a/index.html
+++ b/index.html
@@ -74,9 +74,9 @@
 					// use a timeout here to make sure that the zoom in doesn't try to start before the zoom out has finished
 					setTimeout(
 						function(){
-							console.log(layerBounds, layerID, features);
+//							console.log(layerBounds, layerID, features);
 							features = features.concat(map.querySourceFeatures(sourceID, {'sourceLayer': layerID}));
-							console.log(layerBounds, layerID, features);
+//							console.log(layerBounds, layerID, features);
 							minX = layerBounds[2];
 							maxX = layerBounds[0];
 							minY = layerBounds[3];
@@ -106,12 +106,12 @@
 											}
 										}
 									}
-									console.log(itemID, i, minX, minY, maxX, maxY, coords);
+//									console.log(itemID, i, minX, minY, maxX, maxY, coords);
 								}
 							}
 							// if we found any bounds, zoom to them
-							console.log(minX, minY, maxX, maxY);
-							console.log(layerBounds);
+//							console.log(minX, minY, maxX, maxY);
+//							console.log(layerBounds);
 							if (itemFound) {
 								map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
 							}


### PR DESCRIPTION
This is only half a fix, but please test it and go ahead and merge unless you discover new bugs I've created, because it is still an improvement.  I believe the status quo is now:

1. At iPad Pro screen size or larger (or at least desktop Safari's simulation of that), this works properly (same as before).
2. At any smaller screen size, the first attempt at zooming to a district works (unlike previously), and subsequent attempts at least keep Texas in the viewport rather than flying off to random locations (as they were doing previously).

I haven't got to the bottom of what's going wrong, but I think I have some reasonable workarounds.  For whatever reason, I've noticed two distinct oddities:

- When I query the Mapbox API for the whole school districts layer's bounding box, I get X coordinates of -180 and +180, and Y coords of -85.05 and +85.05.  I'm working around this for now by zooming out to the hardcoded bounds set as a global variable at line 192 (just before defining the `map` element), instead of the bounds I get from the API and that's probably OK since the layer isn't dynamic.
- [The API method to get the list of districts and their shapes](https://www.mapbox.com/mapbox-gl-js/api/#map#querysourcefeatures) is _supposed_ to be unaffected by whether a feature is rendered or not, but also to only return what's within the viewport.  On larger screens this behaves as expected, which is why I have the zoom function zoom out first so it can be sure of getting the complete list of districts.  But on smaller screens, it _won't return anything_ after a zoom out.  So the way I've made the first zoom-to-district work is to make two queries, one before and one after the zoom happens, and combine their results.
- It shouldn't be possible to pan or zoom outside the `maxBounds` that you set when the map element is created, but somehow when it randomly pans us to Morocco or South America it's managing to.  So I've modified the zoomToPolygon() function so it only zooms if it actually found a polygon to zoom to, instead of going to whatever random coordinates it made up in the absence of real data.

I think what I'm going to try next is getting the list of districts in the populateZoomControl() function and storing it then, instead of dynamically fetching the list each time zoomToPolygon() is called.  Because the districts aren't going to change during a user's session, this should solve the problem, but I don't know if I'll have time to complete and test this today - meanwhile at least this PR is a step forward.