### PR TITLE
Better zoom to districts fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,83 +34,91 @@
 			}
 
 			function populateZoomControl(selectID, sourceID, fieldName, layerName) {
-				polygonNames = getIDsList(sourceID, fieldName);
+				polygons = getPolygons(sourceID, fieldName);
 				var select = document.getElementById(selectID);
 				select.options[0] = new Option(layerName);
-				for (i in polygonNames) {
-					select.options[select.options.length] = new Option(polygonNames[i], polygonNames[i]);
+				for (i in polygons) {
+					select.options[select.options.length] = new Option(
+						polygons[i].name,
+						polygons[i].bbox
+					);
 				}
 			}
 
-			function getIDsList(sourceID, fieldName) {
+			function getPolygons(sourceID, nameField) {
 				layerID = map.getSource(sourceID).vectorLayerIds[0];
 				features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID})
-				featureNames = []
+				polygons = [];
+				existingItems = [];
 				for (i in features) {
-					featureName = features[i].properties[fieldName]
-					if (typeof featureName !== undefined) {
-						if (featureNames.indexOf(featureName) < 0) {
-							featureNames.push(featureName);
+					existing = existingItems.indexOf(features[i].properties[nameField]);
+					if (existing > -1) {
+						polygons[existing].bbox = getFeatureBounds(
+							features[i].toJSON().geometry.coordinates,
+							polygons[existing].bbox
+						);
+					}
+					else {
+						existingItems.push(features[i].properties[nameField]);
+						polygons.push({
+							name: features[i].properties[nameField],
+							bbox: getFeatureBounds(features[i].toJSON().geometry.coordinates)
+						});
+					}
+				}
+				polygons.sort(function(a, b){
+					var x = a.name.toLowerCase();
+					var y = b.name.toLowerCase();
+					if (x < y) {return -1;}
+					if (x > y) {return 1;}
+					return 0;
+				});
+				return polygons;
+			}
+
+			function getFeatureBounds(coords, startingBBOX) {
+				if (startingBBOX === undefined) {
+					minX = 180;
+					maxX = -180;
+					minY = 90;
+					maxY = -90;
+				}
+				else {
+					minX = startingBBOX[0][0];
+					maxX = startingBBOX[1][0];
+					minY = startingBBOX[0][1];
+					maxY = startingBBOX[1][1];
+				}
+				for (i in coords) {
+					// coords may be a simple array of coords, or an array of arrays if it's a multipolygon
+					for (j in coords[i]) {
+						if (!(coords[i][j][0] instanceof Array)) {
+							if (coords[i][j][0] < minX) { minX = coords[i][j][0]; }
+							if (coords[i][j][0] > maxX) { maxX = coords[i][j][0]; }
+							if (coords[i][j][1] < minY) { minY = coords[i][j][1]; }
+							if (coords[i][j][1] > maxY) { maxY = coords[i][j][1]; }
+						}
+						else {
+							for (k in coords[i][j]) {
+								if (coords[i][j][k][0] < minX) { minX = coords[i][j][k][0]; }
+								if (coords[i][j][k][0] > maxX) { maxX = coords[i][j][k][0]; }
+								if (coords[i][j][k][1] < minY) { minY = coords[i][j][k][1]; }
+								if (coords[i][j][k][1] > maxY) { maxY = coords[i][j][k][1]; }
+							}
 						}
 					}
 				}
-				// if the IDs are numeric we have to make sure they get sorted as numbers not as text
-				if (typeof featureNames[0] !== undefined && !isNaN(parseFloat(featureNames[0])) && isFinite(featureNames[0])) {
-					return featureNames.sort(function(a, b){return a-b});
-				}
-				else { return featureNames.sort(); }
+				return [[minX, minY], [maxX, maxY]];
 			}
 
-			function zoomToPolygon(sourceID, itemID, fieldName) {
-				// if we have an itemID, then do the main work
-				if (typeof itemID !== 'undefined') {
-					layerBounds = map.getSource(sourceID).bounds;
-					layerID = map.getSource(sourceID).vectorLayerIds[0];
-					features = map.querySourceFeatures(sourceID, {'sourceLayer': layerID});
-					// now zoom out and requery features to make sure we don't miss anything from having been zoomed in
-					map.fitBounds(bounds, options={duration: 0, padding: 100});
-					// use a timeout here to make sure that the zoom in doesn't try to start before the zoom out has finished
-					setTimeout(
-						function(){
-							features = features.concat(map.querySourceFeatures(sourceID, {'sourceLayer': layerID}));
-							minX = layerBounds[2];
-							maxX = layerBounds[0];
-							minY = layerBounds[3];
-							maxY = layerBounds[1];
-							itemFound = false;
-							// then step through features - first to find the item we want
-							for (i in features) {
-								if (features[i].properties[fieldName] == itemID) {
-									itemFound = true;
-									coords = features[i].toJSON().geometry.coordinates;
-									for (j in coords) {
-										// then the coords returned may be a simple array of coords, or an array of arrays if it's a multipolygon
-										for (k in coords[j]) {
-											if (!(coords[j][k][0] instanceof Array)) {
-												if (coords[j][k][0] < minX) { minX = coords[j][k][0]; }
-												if (coords[j][k][0] > maxX) { maxX = coords[j][k][0]; }
-												if (coords[j][k][1] < minY) { minY = coords[j][k][1]; }
-												if (coords[j][k][1] > maxY) { maxY = coords[j][k][1]; }
-											}
-											else {
-												for (l in coords[j][k]) {
-													if (coords[j][k][l][0] < minX) { minX = coords[j][k][l][0]; }
-													if (coords[j][k][l][0] > maxX) { maxX = coords[j][k][l][0]; }
-													if (coords[j][k][l][1] < minY) { minY = coords[j][k][l][1]; }
-													if (coords[j][k][l][1] > maxY) { maxY = coords[j][k][l][1]; }
-												}
-											}
-										}
-									}
-								}
-							}
-							// if we found any bounds, zoom to them
-							if (itemFound) {
-								map.fitBounds([[minX, minY], [maxX, maxY]], options={padding: 10});
-							}
-						},
-						100
-					); // end of setTimeout block
+			function zoomToPolygon(sourceID, coords) {
+				if (typeof coords !== 'undefined') {
+					coords = coords.split(",");
+					bbox = [
+						[coords[0], coords[1]],
+						[coords[2], coords[3]]
+					];
+					map.fitBounds(bbox, options={padding: 10, duration: 5000});
 				}
 			}
 		</script>
@@ -132,7 +140,7 @@
 
 				<!--Drop down controls-->
 
-				<select id="school-districts-control" onchange="zoomToPolygon('texas-school-districts', this.value, 'NAME');"></select>
+				<select id="school-districts-control" onchange="zoomToPolygon('texas-school-districts', this.value);"></select>
 				<br /><br />
 
 				<br /><br />


### PR DESCRIPTION
This is the more complete fix I promised yesterday.  The old behaviour was to store the _names_ of each district as the hidden values in the dropdown menu, and then find the bounding box of an individual district when the user chooses to zoom to it.  The new behaviour is to compute all the bounding boxes at the start, and store _those coordinates_ in the dropdown menu.  This has some advantages:

- The actual zoom to function is now much simpler
- There's no need to zoom out before zooming in, because we already know the bounding box we'll need
- It solves the problems we've been having on small screens

And I can think of at least two potential drawbacks, though they don't seem to be a problem here:

- The `populateZoomControl` function that runs on page load has a lot more work to do because it has to find every district's bbox.  In theory a lot of that is redundant work because we have no way of knowing which district[s] the user will bother zooming to.  In practice I haven't noticed it slowing the page load down, and I'm testing on a fairly old laptop so this is probably safe.
- If the districts could ever change during a user session, my code would miss the change.  I know that's not an issue for this project, but want to flag it in case we do something more dynamic using the Mapbox API some time in future.

I recommend testing this a bit locally, merging it if you don't find any bugs, and if it also works well on RYHT's machines then we may want to make the equivalent change to their other project.